### PR TITLE
Fix Build error

### DIFF
--- a/prusa_connect_rtsp/Dockerfile
+++ b/prusa_connect_rtsp/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILD_FROM
+ARG BUILD_FROM=ghcr.io/home-assistant/amd64-base:latest
 FROM $BUILD_FROM
 
 # Install system dependencies and Python packages from Alpine repos

--- a/prusa_connect_rtsp/Dockerfile
+++ b/prusa_connect_rtsp/Dockerfile
@@ -4,16 +4,16 @@ FROM $BUILD_FROM
 # Install system dependencies and Python packages from Alpine repos
 RUN apk add --no-cache \
     python3 \
-    py3-pip \
     py3-opencv \
     py3-numpy \
     py3-requests \
+    py3-paho-mqtt \
     ffmpeg \
     jq \
     bash
 
 # Install paho-mqtt for Home Assistant MQTT camera discovery
-RUN pip3 install --no-cache-dir --break-system-packages paho-mqtt
+#RUN pip3 install --no-cache-dir --break-system-packages paho-mqtt
 
 # Copy application files
 COPY main.py /

--- a/prusa_connect_rtsp/config.yaml
+++ b/prusa_connect_rtsp/config.yaml
@@ -1,5 +1,5 @@
 name: "Prusa Connect RTSP Camera"
-version: "1.3.1"
+version: "1.3.1-patch1"
 slug: "prusa_connect_rtsp"
 description: "Stream RTSP cameras to Prusa Connect for 3D printer monitoring"
 arch:


### PR DESCRIPTION
I cannot install v1.3.1 due to install error (see separate issue). This is a fix: install paho-mqtt via apk instead of pip.