### PR TITLE
Make BUILD_FROM arch-neutral, add build.yaml

### DIFF
--- a/prusa_connect_rtsp/CHANGELOG.md
+++ b/prusa_connect_rtsp/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [1.3.1-patch1] - 2026-06-17
+
+### Fixed
+
+- Install failure on add-on build: `paho-mqtt` now installs from the Alpine `py3-paho-mqtt` package instead of pip (`--break-system-packages`)
+
+### Changed
+
+- `BUILD_FROM` is arch-neutral again (removed hardcoded amd64 default); added `build.yaml` so the Supervisor selects the correct per-architecture base image
+
 ## [1.3.1] - 2026-02-26
 
 ### Added

--- a/prusa_connect_rtsp/Dockerfile
+++ b/prusa_connect_rtsp/Dockerfile
@@ -1,7 +1,8 @@
-ARG BUILD_FROM=ghcr.io/home-assistant/amd64-base:latest
+ARG BUILD_FROM
 FROM $BUILD_FROM
 
 # Install system dependencies and Python packages from Alpine repos
+# paho-mqtt comes from the Alpine community repo (avoids a pip build at install time)
 RUN apk add --no-cache \
     python3 \
     py3-opencv \
@@ -11,9 +12,6 @@ RUN apk add --no-cache \
     ffmpeg \
     jq \
     bash
-
-# Install paho-mqtt for Home Assistant MQTT camera discovery
-#RUN pip3 install --no-cache-dir --break-system-packages paho-mqtt
 
 # Copy application files
 COPY main.py /

--- a/prusa_connect_rtsp/build.yaml
+++ b/prusa_connect_rtsp/build.yaml
@@ -1,0 +1,6 @@
+build_from:
+  aarch64: ghcr.io/home-assistant/aarch64-base:latest
+  amd64: ghcr.io/home-assistant/amd64-base:latest
+  armhf: ghcr.io/home-assistant/armhf-base:latest
+  armv7: ghcr.io/home-assistant/armv7-base:latest
+  i386: ghcr.io/home-assistant/i386-base:latest


### PR DESCRIPTION
Follow-up to #6.

#6 fixed the install build by switching `paho-mqtt` to the Alpine `py3-paho-mqtt` package, but it also added a hardcoded `ARG BUILD_FROM=ghcr.io/home-assistant/amd64-base:latest` default. That default would pull the **amd64** base on non-amd64 hosts for a bare `docker build` with no args.

## Changes
- **Dockerfile**: drop the amd64 default → plain `ARG BUILD_FROM`; remove the now-dead commented-out pip install line.
- **build.yaml** (new): per-arch `build_from` mapping so the HA Supervisor's local build picks the correct base image per architecture (`config.yaml` has no `image:` key, so users build locally on install).

## Why this is safe
- CI passes `BUILD_FROM` explicitly per matrix arch (`docker-build.yml`), so it never used the Dockerfile default.
- HA Supervisor now reads `build.yaml` for the correct per-arch base and always passes `BUILD_FROM`.
- The default only ever applied to a bare `docker build` with no args, which isn't how this addon is consumed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)