### PR TITLE
Back off uploads when Prusa Connect rejects frames (printer offline)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# Python
+__pycache__/
+*.py[cod]

--- a/README.md
+++ b/README.md
@@ -45,6 +45,22 @@ cameras:
     timelapse_enabled: false
 ```
 
+## Troubleshooting
+
+### Camera images don't appear in Prusa Connect while the printer is off
+
+This is expected. Prusa Connect only accepts and displays webcam snapshots while
+the associated printer is **online**. The add-on keeps capturing and uploading
+frames regardless, but Prusa's server rejects them until the printer reconnects —
+so the snapshot simply stops updating in Connect until the printer is back on.
+
+To avoid flooding the log and hammering Prusa's endpoint during this time, the
+add-on automatically backs off: after several consecutive rejected uploads it
+progressively increases the interval between attempts (up to 5 minutes), logs a
+single "backing off" message, and returns to the normal `upload_interval` with an
+"uploads resumed" message as soon as the printer comes back online. No action is
+needed — images resume on their own.
+
 ## Credits
 
 This add-on wraps [Prusa-Connect-RTSP](https://github.com/Knopersikcuo/Prusa-Connect-RTSP) by Knopersikcuo.

--- a/prusa_connect_rtsp/main.py
+++ b/prusa_connect_rtsp/main.py
@@ -21,6 +21,12 @@ PRUSA_URL = "https://webcam.connect.prusa3d.com/c/snapshot"
 # Upload frequency configuration (in seconds)
 UPLOAD_INTERVAL = int(os.environ.get("UPLOAD_INTERVAL", "5"))  # Default 5 seconds
 
+# When uploads keep failing (e.g. printer offline in Prusa Connect, which rejects
+# snapshots until the printer reconnects), progressively slow down instead of
+# hammering the endpoint and flooding the log every UPLOAD_INTERVAL seconds.
+OFFLINE_BACKOFF_THRESHOLD = int(os.environ.get("OFFLINE_BACKOFF_THRESHOLD", "3"))  # consecutive failures before backing off
+OFFLINE_BACKOFF_MAX = int(os.environ.get("OFFLINE_BACKOFF_MAX", "300"))            # max seconds between attempts while backed off
+
 # Timelapse configuration
 ENABLE_TIMELAPSE = os.environ.get("ENABLE_TIMELAPSE", "false").lower() == "true"
 TIMELAPSE_SAVE_INTERVAL = int(os.environ.get("TIMELAPSE_SAVE_INTERVAL", "30"))  # Save frame every X seconds
@@ -373,6 +379,8 @@ print("✅ Camera connection working. Starting frame upload...")
 frame_count = 0
 successful_uploads = 0
 last_timelapse_save = 0
+consecutive_failures = 0
+backoff_active = False
 
 try:
     while True:
@@ -414,21 +422,44 @@ try:
 
         if success and status_code == 200:
             successful_uploads += 1
+            if backoff_active:
+                print("✅ Uploads accepted again — resuming normal interval")
+                backoff_active = False
+            consecutive_failures = 0
+            sleep_time = UPLOAD_INTERVAL
             print(f"📤 Frame #{frame_count} sent successfully. Size: {len(image_bytes)} bytes. Success: {successful_uploads}/{frame_count}")
-        elif success and status_code == 429:
-            print(f"⚠️ Rate limit exceeded! Increase UPLOAD_INTERVAL (current: {UPLOAD_INTERVAL}s)")
-            time.sleep(UPLOAD_INTERVAL * 2)  # Wait longer after rate limit
         else:
-            print(f"⚠️ Upload error #{frame_count}: {status_code} - {response_text}")
-            # Display error details
-            if status_code == 401:
-                print("💡 Check if token and fingerprint are correct")
-            elif status_code == 400:
-                print("💡 Check data format - possible Content-Length issue")
-            elif not success:
-                print("💡 Connection error - check internet connection")
+            consecutive_failures += 1
 
-        time.sleep(UPLOAD_INTERVAL)
+            # Only log the detailed error while we're not yet in steady backoff,
+            # so a persistently offline printer doesn't flood the log every tick.
+            if not backoff_active:
+                if success and status_code == 429:
+                    print(f"⚠️ Rate limit exceeded! Increase UPLOAD_INTERVAL (current: {UPLOAD_INTERVAL}s)")
+                else:
+                    print(f"⚠️ Upload error #{frame_count}: {status_code} - {response_text}")
+                    if status_code == 401:
+                        print("💡 Check if token and fingerprint are correct")
+                    elif status_code == 400:
+                        print("💡 Check data format - possible Content-Length issue")
+                    elif not success:
+                        print("💡 Connection error - check internet connection")
+
+            if consecutive_failures >= OFFLINE_BACKOFF_THRESHOLD:
+                # Exponential backoff, capped, so we stop hammering Prusa while it
+                # keeps rejecting frames (typically because the printer is offline).
+                sleep_time = min(
+                    UPLOAD_INTERVAL * 2 ** (consecutive_failures - OFFLINE_BACKOFF_THRESHOLD + 1),
+                    OFFLINE_BACKOFF_MAX,
+                )
+                if not backoff_active:
+                    backoff_active = True
+                    print(f"⏸️ Prusa Connect keeps rejecting frames (printer offline?). "
+                          f"Backing off to up to {OFFLINE_BACKOFF_MAX}s between attempts until it recovers.")
+            else:
+                sleep_time = UPLOAD_INTERVAL
+
+        time.sleep(sleep_time)
 
 except KeyboardInterrupt:
     print("\n🛑 Stopped by user")


### PR DESCRIPTION
Closes #8.

## Context

Issue #8 reports "No image when printer is off." This is **expected Prusa Connect behavior, not a bug**: the add-on has no concept of printer state — it captures a frame and PUTs it to the snapshot endpoint every `upload_interval` seconds, unconditionally. Prusa Connect only accepts/displays webcam snapshots while the associated printer is **online**, so while the printer is off the server rejects every frame (non-200) and the snapshot simply stops updating until the printer reconnects.

The previous code kept uploading at full rate and logged a warning on *every* tick during this time, hammering Prusa's endpoint and flooding the add-on log.

## Changes

- **`prusa_connect_rtsp/main.py`** — Added a consecutive-failure backoff to the upload loop:
  - After `OFFLINE_BACKOFF_THRESHOLD` (default 3) consecutive failed uploads, the retry interval grows exponentially, capped at `OFFLINE_BACKOFF_MAX` (default 300s / 5 min).
  - Logs a single `⏸️ … Backing off …` line on entering backoff instead of a per-tick warning, and a single `✅ Uploads accepted again …` line on recovery, then returns to the normal `upload_interval`.
  - Detection is by consecutive failures rather than a specific status code, so it's robust to whatever status Prusa returns for an offline printer, and it subsumes the previous one-off 429 rate-limit handling. Single transient failures don't trigger backoff. Both thresholds are env-overridable (consistent with existing `CONNECT_RETRIES`), no HA UI change required.
- **`README.md`** — Added a Troubleshooting section explaining the printer-offline behavior so users understand it's expected and that images resume on their own.
- **`.gitignore`** — Ignore Python bytecode artifacts.

## Verification

- `python3 -m py_compile prusa_connect_rtsp/main.py` passes.
- Simulated the offline → backoff → recovery sequence: interval ramps 5 → 10 → 20 → … → 300s, exactly one "backing off" log, no per-tick flooding, and exactly one "resumed" log with a return to the normal interval when uploads succeed again. A single transient failure below the threshold does not change behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ABiKmGaoSjpyqjJ68tSjPf)_