### PR TITLE
Pull prebuilt images from GHCR so installs are measurable

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -5,8 +5,6 @@ on:
     branches: [main]
     paths:
       - 'prusa_connect_rtsp/**'
-  release:
-    types: [published]
   workflow_dispatch:
 
 env:

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -50,6 +50,12 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Read addon version
+        id: addon
+        run: |
+          VERSION=$(grep '^version:' prusa_connect_rtsp/config.yaml | sed -E 's/version:[[:space:]]*"?([^"]+)"?/\1/')
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
       - name: Build and push
         uses: docker/build-push-action@v5
         with:
@@ -58,6 +64,7 @@ jobs:
           platforms: ${{ matrix.platform }}
           tags: |
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-${{ matrix.arch }}:latest
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-${{ matrix.arch }}:${{ steps.addon.outputs.version }}
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-${{ matrix.arch }}:${{ github.sha }}
           build-args: |
             BUILD_FROM=ghcr.io/home-assistant/${{ matrix.arch }}-base:latest

--- a/prusa_connect_rtsp/CHANGELOG.md
+++ b/prusa_connect_rtsp/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.3.5] - 2026-07-09
+
+### Changed
+
+- Supervisor now pulls prebuilt per-architecture images from GHCR instead of building the add-on locally on each device (added `image:` key). Installs are faster and no longer ship a build toolchain to every device.
+- CI now tags pushed images with the add-on version (e.g. `1.3.5`) so the Supervisor can resolve the correct image, alongside the existing `latest`/commit tags.
+
 ## [1.3.4] - 2026-07-06
 
 ### Fixed

--- a/prusa_connect_rtsp/config.yaml
+++ b/prusa_connect_rtsp/config.yaml
@@ -2,6 +2,7 @@ name: "Prusa Connect RTSP Camera"
 version: "1.3.4"
 slug: "prusa_connect_rtsp"
 description: "Stream RTSP cameras to Prusa Connect for 3D printer monitoring"
+image: "ghcr.io/schmacka/rtsp-to-prusa-ha-{arch}"
 arch:
   - aarch64
   - amd64

--- a/prusa_connect_rtsp/config.yaml
+++ b/prusa_connect_rtsp/config.yaml
@@ -1,5 +1,5 @@
 name: "Prusa Connect RTSP Camera"
-version: "1.3.4"
+version: "1.3.5"
 slug: "prusa_connect_rtsp"
 description: "Stream RTSP cameras to Prusa Connect for 3D printer monitoring"
 image: "ghcr.io/schmacka/rtsp-to-prusa-ha-{arch}"


### PR DESCRIPTION
## Why

The add-on had no `image:` key in `config.yaml`, so Home Assistant Supervisor **builds the image locally on every user's device** instead of pulling from GHCR. As a result the GHCR pull counts (amd64: 0, aarch64: 6, armv7: 114, armhf: 150, i386: 74) reflect essentially no real user signal — they can't be used to gauge installs, and the CI-built images are never pulled by any installation.

## What changed

- **`config.yaml`** — added `image: "ghcr.io/schmacka/rtsp-to-prusa-ha-{arch}"`. Supervisor now pulls prebuilt per-arch images instead of building locally. Installs are faster and no build toolchain ships to each device. Going forward, GHCR pull counts become a real install-and-update metric.
- **`config.yaml`** — bumped version `1.3.4` → `1.3.5` so the first version users pull under the new scheme corresponds to a fresh CI build (the `1.3.5` tag will be created by this workflow on merge).
- **`docker-build.yml`** — added a step that reads `version:` from `config.yaml` and tags pushed images with it (e.g. `...-{arch}:1.3.5`), which is the tag Supervisor resolves. Existing `latest`/commit tags are kept.
- **`docker-build.yml`** — removed the `release: published` trigger. Publishing a GitHub Release isn't part of this repo's flow and push-to-`main` already builds every change.
- **`CHANGELOG.md`** — documented the switch.

## Rollout note

The `image:` key means Supervisor pulls `...:1.3.5` on install/update. That tag doesn't exist in GHCR yet — it's produced by this workflow when the change lands on `main`. So the correct order is **merge → workflow builds & pushes `:1.3.5` → users can install/update**. Merging builds the required tag before anyone pulls it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XB1wfpatUY8KQNF1yZnxH2)_